### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-spring to 1.9.1

### DIFF
--- a/renren-admin/pom.xml
+++ b/renren-admin/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<groupId>io.renren</groupId>
@@ -11,7 +12,7 @@
 
 	<properties>
 		<quartz.version>2.3.2</quartz.version>
-		<shiro.version>1.9.0</shiro.version>
+		<shiro.version>1.9.1</shiro.version>
 		<captcha.version>1.6.2</captcha.version>
 		<easypoi.version>4.1.0</easypoi.version>
 		<qiniu.version>7.2.27</qiniu.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-spring 1.9.0
- [CVE-2022-32532](https://www.oscs1024.com/hd/CVE-2022-32532)


### What did I do？
Upgrade org.apache.shiro:shiro-spring from 1.9.0 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS